### PR TITLE
Multi-window support

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,15 +20,11 @@ to visualize in the editor.
 ![An example of the editor running the Pong example game.](screenshots/pong.gif)
 
 Once your game is setup using [amethyst-editor-sync], you can simply run the game alongside the
-editor and the editor will automatically begin displaying your game's state. On the left is the list
-of entities, including the components attached to each entity. Clicking on an entity will show the
-data for each of the entity's components in the middle column. The right column displays the list of
-resources and the current state for each one.
-
-> NOTE: Running more than one instance of the editor or more than one game with editor support is
-> not currently supported. Doing so will causes errors/crashes in the editor, and you will not be
-> able to use multiple editor instances to debug multiple games at once. This functionality may
-> still be added though, see the issue tracker if you'd like to request this feature.
+editor and the editor will automatically begin displaying your game's state. When launched, the
+editor will not immediately open a window. Rather, it will run as a background process until you
+launch your game, at which point it will automatically open an editor window for the game. This also
+works if you have multiple games running, such as a server and multiple client instances for a
+multiplayer game.
 
 ## Motivation and Philosophy
 

--- a/main.js
+++ b/main.js
@@ -34,6 +34,12 @@ function getOrCreateWindow(port) {
     return window;
 }
 
+// Handle the 'windows-all-closed' event to prevent the default behavior of
+// quitting the application when all windows have closed. We want the main
+// process to continue to run in the background so that we can automatically
+// open editor windows as the user launches their game.
+app.on('window-all-closed', function() {});
+
 // This method will be called when Electron has finished
 // initialization and is ready to create browser windows.
 // Some APIs can only be used after this event occurs.

--- a/main.js
+++ b/main.js
@@ -28,7 +28,7 @@ function getOrCreateWindow(port) {
 
     // Emitted when the window is closed.
     window.on('closed', function() {
-        delete windows.port;
+        delete windows[port];
     });
 
     return window;

--- a/main.js
+++ b/main.js
@@ -3,77 +3,57 @@ const {
     app,
     BrowserWindow,
 } = require('electron');
-const childProcess = require('child_process');
-const path = require('path');
 const ipc = require('node-ipc');
 
-// Keep a global reference of the window object, if you don't, the window will
-// be closed automatically when the JavaScript object is garbage collected.
-let mainWindow;
+// Dictionary of active window objects, with the key being the port the window is connected from.
+// Windows are removed from the dictionary when they close.
+let windows = {};
 
-function createWindow() {
+function getOrCreateWindow(port) {
+    // If there is already a window for the specified port, fetch it from `windows`.
+    if (port in windows) {
+        return windows[port];
+    }
+
     // Create the browser window.
-    mainWindow = new BrowserWindow({
+    let window = new BrowserWindow({
         width: 800,
         height: 600
     });
 
     // and load the index.html of the app.
-    mainWindow.loadFile('index.html');
+    window.loadFile('index.html');
 
-    // Open the DevTools.
-    // mainWindow.webContents.openDevTools()
+    windows[port] = window;
 
     // Emitted when the window is closed.
-    mainWindow.on('closed', function() {
-        // Dereference the window object, usually you would store windows
-        // in an array if your app supports multi windows, this is the time
-        // when you should delete the corresponding element.
-        mainWindow = null;
+    window.on('closed', function() {
+        delete windows.port;
     });
+
+    return window;
 }
 
 // This method will be called when Electron has finished
 // initialization and is ready to create browser windows.
 // Some APIs can only be used after this event occurs.
-app.on('ready', createWindow);
+app.on('ready', () => {
+    ipc.config.id = 'world';
+    ipc.config.retry = 1500;
+    ipc.config.silent = true;
 
-// Quit when all windows are closed.
-app.on('window-all-closed', function() {
-    // On OS X it is common for applications and their menu bar
-    // to stay active until the user quits explicitly with Cmd + Q
-    if (process.platform !== 'darwin') {
-        app.quit();
-    }
-});
-
-app.on('activate', function() {
-    // On OS X it's common to re-create a window in the app when the
-    // dock icon is clicked and there are no other windows open.
-    if (mainWindow === null) {
-        createWindow();
-    }
-});
-
-// In this file you can include the rest of your app's specific main process
-// code. You can also put them in separate files and require them here.
-
-ipc.config.id = 'world';
-ipc.config.retry = 1500;
-ipc.config.silent = true;
-
-ipc.serveNet(
-    'udp4',
-    function() {
-        ipc.server.on(
-            'message',
-            function(data, socket) {
-                if (mainWindow !== null) {
-                    mainWindow.webContents.send('message', data);
+    ipc.serveNet(
+        'udp4',
+        function() {
+            ipc.server.on(
+                'message',
+                function(data, socket) {
+                    let window = getOrCreateWindow(socket.port);
+                    window.webContents.send('message', data);
                 }
-            }
-        );
-    }
-);
+            );
+        }
+    );
 
-ipc.server.start();
+    ipc.server.start();
+});

--- a/main.js
+++ b/main.js
@@ -34,6 +34,12 @@ function getOrCreateWindow(port) {
     return window;
 }
 
+function handleTimeout(port) {
+    if (port in windows) {
+        windows[port].close();
+    }
+}
+
 // Handle the 'windows-all-closed' event to prevent the default behavior of
 // quitting the application when all windows have closed. We want the main
 // process to continue to run in the background so that we can automatically
@@ -56,6 +62,12 @@ app.on('ready', () => {
                 function(data, socket) {
                     let window = getOrCreateWindow(socket.port);
                     window.webContents.send('message', data);
+
+                    // Reset the timeout since we recieved a message from the game.
+                    if ('timeout' in window) {
+                        clearTimeout(window.timeout);
+                    }
+                    window.timeout = setTimeout(handleTimeout, 500, socket.port);
                 }
             );
         }


### PR DESCRIPTION
Change the editor to automatically open a new window for each connected game, rather than having a single global window open at all times. This allows the editor to work smoothly with client/server games, or any other case where a user would want to have multiple Amethyst games running at once.