### PR TITLE
Single window mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@
       <!-- Tabs for selecting the active game. -->
       <div class="tabs" v-if="gameIds.length > 1">
         <ul>
-          <li v-for="(gameId, index) in games" v-bind:class="{ 'is-active': index === activeGame }">
+          <li v-for="(gameId, index) in gameIds" v-bind:class="{ 'is-active': index === activeGame }">
             <a v-on:click="selectGame(index)">{{ gameId }}</a>
           </li>
         </ul>

--- a/index.html
+++ b/index.html
@@ -14,27 +14,31 @@
   <body>
     <div id="app" class="section">
       <!-- Help message to display when no games are connected. -->
-      <div v-if="games.length == 0">
-        Run your game to begin debugging
-      </div>
+      <section class="hero is-fullheight" v-if="gameIds.length == 0">
+        <div class="hero-body"v-if="gameIds.length == 0">
+          <h1 class="title">
+            Run your game in order to start debugging
+          </h1>
+        </div>
+      </section>
 
       <!-- Tabs for selecting the active game. -->
-      <div class="tabs" v-if="games.length > 1">
+      <div class="tabs" v-if="gameIds.length > 1">
         <ul>
-          <li v-for="(game, index) in games" v-bind:class="{ 'is-active': index === activeGame }">
-            <a v-on:click="selectGame(index)">Game</a>
+          <li v-for="(gameId, index) in games" v-bind:class="{ 'is-active': index === activeGame }">
+            <a v-on:click="selectGame(index)">{{ gameId }}</a>
           </li>
         </ul>
       </div>
 
       <!-- Currently selected game. -->
-      <div v-for="(game, index) in games" v-if="index === activeGame">
+      <div v-for="(gameId, index) in gameIds" v-if="gameIds.length > 0 && index === activeGame">
         <!-- Tabs bar at the top of the page. -->
         <div class="tabs is-centered">
           <ul>
             <li
               v-for="(tab, index) in tabs"
-              v-bind:class="{ 'is-active': activeTab === index }"
+              v-bind:class="{ 'is-active': games[gameId].activeTab === index }"
             >
               <a v-on:click="selectTab(index)">{{ tab }}</a>
             </li>
@@ -42,13 +46,13 @@
         </div>
 
         <!-- Entities tab. -->
-        <div v-if="activeTab === 0" class="columns">
+        <div v-if="games[gameId].activeTab === 0" class="columns">
           <div class="column is-one-fifth">
             <nav class="panel">
               <h2 class="panel-heading">Entities</h2>
                 <a
-                  v-for="entity in entities"
-                  v-bind:class="{ 'is-active': entity.id === selectedEntity }"
+                  v-for="entity in games[gameId].entities"
+                  v-bind:class="{ 'is-active': entity.id === games[gameId].selectedEntity }"
                   v-on:click="selectEntity(entity.id)"
                   class="panel-block"
                 >
@@ -56,7 +60,7 @@
 
                   <div class="tags">
                     <span
-                      v-for="component in components"
+                      v-for="component in games[gameId].components"
                       v-if="component.data[entity.id] !== undefined"
                       v-bind:class="{
                         'is-primary': component.data[entity.id] !== null,
@@ -71,24 +75,24 @@
             </nav>
           </div>
 
-          <div v-if="selectedEntity != null" class="column">
+          <div v-if="games[gameId].selectedEntity != null" class="column">
             <div class="tags">
-              <div v-for="componentType in components" v-if="componentType.data[selectedEntity] === null" class="tag is-info is-large">
+              <div v-for="componentType in games[gameId].components" v-if="componentType.data[games[gameId].selectedEntity] === null" class="tag is-info is-large">
                 {{ componentType.name }}
               </div>
             </div>
-            <div v-for="componentType in components" v-if="componentType.data[selectedEntity] != null" class="box content">
+            <div v-for="componentType in games[gameId].components" v-if="componentType.data[games[gameId].selectedEntity] != null" class="box content">
               <h3 class="title is-3">{{ componentType.name }}</h3>
                 <vue-json-pretty
-                  :data="componentType.data[selectedEntity]"
+                  :data="componentType.data[games[gameId].selectedEntity]"
                 ></vue-json-pretty>
             </div>
           </div>
         </div>
 
         <!-- Resources tab. -->
-        <div v-if="activeTab === 1">
-          <div v-for="resource in resources" class="box content">
+        <div v-if="games[gameId].activeTab === 1">
+          <div v-for="resource in games[gameId].resources" class="box content">
             <h3 class="title is-3">{{ resource.name }}</h3>
             <vue-json-pretty
               :data="resource.data"

--- a/index.html
+++ b/index.html
@@ -13,70 +13,87 @@
   </head>
   <body>
     <div id="app" class="section">
-      <!-- Tabs bar at the top of the page. -->
-      <div class="tabs is-centered">
+      <!-- Help message to display when no games are connected. -->
+      <div v-if="games.length == 0">
+        Run your game to begin debugging
+      </div>
+
+      <!-- Tabs for selecting the active game. -->
+      <div class="tabs" v-if="games.length > 1">
         <ul>
-          <li
-            v-for="(tab, index) in tabs"
-            v-bind:class="{ 'is-active': activeTab === index }"
-          >
-            <a v-on:click="selectTab(index)">{{ tab }}</a>
+          <li v-for="(game, index) in games" v-bind:class="{ 'is-active': index === activeGame }">
+            <a v-on:click="selectGame(index)">Game</a>
           </li>
         </ul>
       </div>
 
-      <!-- Entities tab. -->
-      <div v-if="activeTab === 0" class="columns">
-        <div class="column is-one-fifth">
-          <nav class="panel">
-            <h2 class="panel-heading">Entities</h2>
-              <a
-                v-for="entity in entities"
-                v-bind:class="{ 'is-active': entity.id === selectedEntity }"
-                v-on:click="selectEntity(entity.id)"
-                class="panel-block"
-              >
-                <span class="panel-icon">{{ entity.id }}</span>
-
-                <div class="tags">
-                  <span
-                    v-for="component in components"
-                    v-if="component.data[entity.id] !== undefined"
-                    v-bind:class="{
-                      'is-primary': component.data[entity.id] !== null,
-                      'is-info': component.data[entity.id] === null,
-                    }"
-                    class="tag"
-                  >
-                    {{ component.name }}
-                  </span>
-                </div>
-              </a>
-          </nav>
+      <!-- Currently selected game. -->
+      <div v-for="(game, index) in games" v-if="index === activeGame">
+        <!-- Tabs bar at the top of the page. -->
+        <div class="tabs is-centered">
+          <ul>
+            <li
+              v-for="(tab, index) in tabs"
+              v-bind:class="{ 'is-active': activeTab === index }"
+            >
+              <a v-on:click="selectTab(index)">{{ tab }}</a>
+            </li>
+          </ul>
         </div>
 
-        <div v-if="selectedEntity != null" class="column">
-          <div class="tags">
-            <div v-for="componentType in components" v-if="componentType.data[selectedEntity] === null" class="tag is-info is-large">
-              {{ componentType.name }}
+        <!-- Entities tab. -->
+        <div v-if="activeTab === 0" class="columns">
+          <div class="column is-one-fifth">
+            <nav class="panel">
+              <h2 class="panel-heading">Entities</h2>
+                <a
+                  v-for="entity in entities"
+                  v-bind:class="{ 'is-active': entity.id === selectedEntity }"
+                  v-on:click="selectEntity(entity.id)"
+                  class="panel-block"
+                >
+                  <span class="panel-icon">{{ entity.id }}</span>
+
+                  <div class="tags">
+                    <span
+                      v-for="component in components"
+                      v-if="component.data[entity.id] !== undefined"
+                      v-bind:class="{
+                        'is-primary': component.data[entity.id] !== null,
+                        'is-info': component.data[entity.id] === null,
+                      }"
+                      class="tag"
+                    >
+                      {{ component.name }}
+                    </span>
+                  </div>
+                </a>
+            </nav>
+          </div>
+
+          <div v-if="selectedEntity != null" class="column">
+            <div class="tags">
+              <div v-for="componentType in components" v-if="componentType.data[selectedEntity] === null" class="tag is-info is-large">
+                {{ componentType.name }}
+              </div>
+            </div>
+            <div v-for="componentType in components" v-if="componentType.data[selectedEntity] != null" class="box content">
+              <h3 class="title is-3">{{ componentType.name }}</h3>
+                <vue-json-pretty
+                  :data="componentType.data[selectedEntity]"
+                ></vue-json-pretty>
             </div>
           </div>
-          <div v-for="componentType in components" v-if="componentType.data[selectedEntity] != null" class="box content">
-            <h3 class="title is-3">{{ componentType.name }}</h3>
-              <vue-json-pretty
-                :data="componentType.data[selectedEntity]"
-              ></vue-json-pretty>
-          </div>
         </div>
-      </div>
 
-      <!-- Resources tab. -->
-      <div v-if="activeTab === 1">
-        <div v-for="resource in resources" class="box content">
-          <h3 class="title is-3">{{ resource.name }}</h3>
-          <vue-json-pretty
-            :data="resource.data"
-          ></vue-json-pretty>
+        <!-- Resources tab. -->
+        <div v-if="activeTab === 1">
+          <div v-for="resource in resources" class="box content">
+            <h3 class="title is-3">{{ resource.name }}</h3>
+            <vue-json-pretty
+              :data="resource.data"
+            ></vue-json-pretty>
+          </div>
         </div>
       </div>
     </div>

--- a/index.html
+++ b/index.html
@@ -11,34 +11,48 @@
     <!-- development version, includes helpful console warnings -->
     <script src="node_modules/vue/dist/vue.js"></script>
   </head>
-  <body>
-    <div id="app" class="section">
+
+  <body class="has-navbar-fixed-top">
+    <div id="app" class="">
       <!-- Help message to display when no games are connected. -->
-      <section class="hero is-fullheight" v-if="gameIds.length == 0">
-        <div class="hero-body"v-if="gameIds.length == 0">
-          <h1 class="title">
-            Run your game in order to start debugging
-          </h1>
+      <section
+        v-if="gameIds.length == 0"
+        class="hero is-info is-fullheight is-fullwidth is-medium"
+      >
+        <div class="hero-head"></div>
+        <div class="hero-body" v-if="gameIds.length == 0">
+          <div class="container has-text-centered">
+            <h1 class="title">
+              Run your game to start debugging
+            </h1>
+          </div>
         </div>
+        <div class="hero-foot"></div>
       </section>
 
       <!-- Tabs for selecting the active game. -->
-      <div class="tabs" v-if="gameIds.length > 1">
-        <ul>
-          <li v-for="(gameId, index) in gameIds" v-bind:class="{ 'is-active': index === activeGame }">
-            <a v-on:click="selectGame(index)">{{ gameId }}</a>
-          </li>
-        </ul>
-      </div>
+      <nav v-if="gameIds.length > 1" class="navbar is-fixed-top">
+        <div class="navbar-item is-expanded tabs is-boxed">
+          <ul>
+            <li
+              v-for="(gameId, index) in gameIds"
+              v-bind:class="{ 'is-active': index === activeGameIndex }"
+            >
+              <a v-on:click="selectGame(index)">{{ gameId }}</a>
+            </li>
+          </ul>
+        </div>
+      </nav>
 
       <!-- Currently selected game. -->
-      <div v-for="(gameId, index) in gameIds" v-if="gameIds.length > 0 && index === activeGame">
+      <section v-if="gameIds.length > 0" class="section">
+
         <!-- Tabs bar at the top of the page. -->
-        <div class="tabs is-centered">
+        <div class="tabs is-centered is-toggle">
           <ul>
             <li
               v-for="(tab, index) in tabs"
-              v-bind:class="{ 'is-active': games[gameId].activeTab === index }"
+              v-bind:class="{ 'is-active': activeGame().activeTab === index }"
             >
               <a v-on:click="selectTab(index)">{{ tab }}</a>
             </li>
@@ -46,13 +60,13 @@
         </div>
 
         <!-- Entities tab. -->
-        <div v-if="games[gameId].activeTab === 0" class="columns">
+        <div v-if="activeGame().activeTab === 0" class="columns">
           <div class="column is-one-fifth">
             <nav class="panel">
               <h2 class="panel-heading">Entities</h2>
                 <a
-                  v-for="entity in games[gameId].entities"
-                  v-bind:class="{ 'is-active': entity.id === games[gameId].selectedEntity }"
+                  v-for="entity in activeGame().entities"
+                  v-bind:class="{ 'is-active': entity.id === activeGame().selectedEntity }"
                   v-on:click="selectEntity(entity.id)"
                   class="panel-block"
                 >
@@ -60,7 +74,7 @@
 
                   <div class="tags">
                     <span
-                      v-for="component in games[gameId].components"
+                      v-for="component in activeGame().components"
                       v-if="component.data[entity.id] !== undefined"
                       v-bind:class="{
                         'is-primary': component.data[entity.id] !== null,
@@ -75,31 +89,37 @@
             </nav>
           </div>
 
-          <div v-if="games[gameId].selectedEntity != null" class="column">
+          <div v-if="activeGame().selectedEntity != null" class="column">
             <div class="tags">
-              <div v-for="componentType in games[gameId].components" v-if="componentType.data[games[gameId].selectedEntity] === null" class="tag is-info is-large">
+              <div
+                v-for="componentType in activeGame().components"
+                v-if="componentType.data[activeGame().selectedEntity] === null"
+                class="tag is-info is-large"
+              >
                 {{ componentType.name }}
               </div>
             </div>
-            <div v-for="componentType in games[gameId].components" v-if="componentType.data[games[gameId].selectedEntity] != null" class="box content">
+            <div
+              v-for="componentType in activeGame().components"
+              v-if="componentType.data[activeGame().selectedEntity] != null"
+              class="box content"
+            >
               <h3 class="title is-3">{{ componentType.name }}</h3>
                 <vue-json-pretty
-                  :data="componentType.data[games[gameId].selectedEntity]"
+                  :data="componentType.data[activeGame().selectedEntity]"
                 ></vue-json-pretty>
             </div>
           </div>
         </div>
 
         <!-- Resources tab. -->
-        <div v-if="games[gameId].activeTab === 1">
-          <div v-for="resource in games[gameId].resources" class="box content">
+        <div v-if="activeGame().activeTab === 1">
+          <div v-for="resource in activeGame().resources" class="box content">
             <h3 class="title is-3">{{ resource.name }}</h3>
-            <vue-json-pretty
-              :data="resource.data"
-            ></vue-json-pretty>
+            <vue-json-pretty :data="resource.data"></vue-json-pretty>
           </div>
         </div>
-      </div>
+      </section>
     </div>
 
     <script>

--- a/main.js
+++ b/main.js
@@ -5,16 +5,7 @@ const {
 } = require('electron');
 const ipc = require('node-ipc');
 
-// Dictionary of active window objects, with the key being the port the window is connected from.
-// Windows are removed from the dictionary when they close.
-let windows = {};
-
-function getOrCreateWindow(port) {
-    // If there is already a window for the specified port, fetch it from `windows`.
-    if (port in windows) {
-        return windows[port];
-    }
-
+function createWindow() {
     // Create the browser window.
     let window = new BrowserWindow({
         width: 800,
@@ -24,32 +15,23 @@ function getOrCreateWindow(port) {
     // and load the index.html of the app.
     window.loadFile('index.html');
 
-    windows[port] = window;
-
-    // Emitted when the window is closed.
-    window.on('closed', function() {
-        delete windows[port];
-    });
-
     return window;
 }
 
-function handleTimeout(port) {
-    if (port in windows) {
-        windows[port].close();
-    }
+function handleTimeout(windowId) {
+    window.webContents.send('disconnect', { id: windowId });
+    delete timeouts[windowId];
 }
 
-// Handle the 'windows-all-closed' event to prevent the default behavior of
-// quitting the application when all windows have closed. We want the main
-// process to continue to run in the background so that we can automatically
-// open editor windows as the user launches their game.
-app.on('window-all-closed', function() {});
+let window;
+let timeouts = {};
 
 // This method will be called when Electron has finished
 // initialization and is ready to create browser windows.
 // Some APIs can only be used after this event occurs.
 app.on('ready', () => {
+    window = createWindow();
+
     ipc.config.id = 'world';
     ipc.config.retry = 1500;
     ipc.config.silent = true;
@@ -60,18 +42,43 @@ app.on('ready', () => {
             ipc.server.on(
                 'message',
                 function(data, socket) {
-                    let window = getOrCreateWindow(socket.port);
-                    window.webContents.send('message', data);
+                    let windowId = socket.port;
 
                     // Reset the timeout since we recieved a message from the game.
-                    if ('timeout' in window) {
-                        clearTimeout(window.timeout);
+                    if (windowId in timeouts) {
+                        clearTimeout(timeouts[windowId]);
+                        window.webContents.send('update', {
+                            id: windowId,
+                            data: data,
+                        });
+                    } else {
+                        window.webContents.send('connect', {
+                            id: windowId,
+                            data: data,
+                        });
                     }
-                    window.timeout = setTimeout(handleTimeout, 500, socket.port);
+                    timeouts[windowId] = setTimeout(handleTimeout, 500, socket.port);
                 }
             );
         }
     );
 
     ipc.server.start();
+});
+
+// Quit when all windows are closed.
+app.on('window-all-closed', function() {
+    // On OS X it is common for applications and their menu bar
+    // to stay active until the user quits explicitly with Cmd + Q
+    if (process.platform !== 'darwin') {
+        app.quit();
+    }
+});
+
+app.on('activate', function() {
+    // On OS X it's common to re-create a window in the app when the
+    // dock icon is clicked and there are no other windows open.
+    if (mainWindow === null) {
+        createWindow();
+    }
 });

--- a/main.js
+++ b/main.js
@@ -30,6 +30,14 @@ let timeouts = {};
 // initialization and is ready to create browser windows.
 // Some APIs can only be used after this event occurs.
 app.on('ready', () => {
+    // TODO: Only do this for dev builds.
+    let installExtension = require('electron-devtools-installer')
+      installExtension.default(installExtension.VUEJS_DEVTOOLS)
+        .then(() => {})
+        .catch(err => {
+            console.log('Unable to install `vue-devtools`: \n', err)
+        });
+
     window = createWindow();
 
     ipc.config.id = 'world';

--- a/main.js
+++ b/main.js
@@ -63,16 +63,12 @@ app.on('ready', () => {
                     // Reset the timeout since we recieved a message from the game.
                     if (windowId in timeouts) {
                         clearTimeout(timeouts[windowId]);
-                        mainWindow.webContents.send('update', {
-                            id: windowId,
-                            data: data,
-                        });
-                    } else {
-                        mainWindow.webContents.send('connect', {
-                            id: windowId,
-                            data: data,
-                        });
                     }
+
+                    mainWindow.webContents.send('data', {
+                        id: windowId,
+                        data: data,
+                    });
                     timeouts[windowId] = setTimeout(handleTimeout, 500, socket.port);
                 }
             );

--- a/package-lock.json
+++ b/package-lock.json
@@ -465,6 +465,11 @@
       "integrity": "sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A==",
       "dev": true
     },
+    "clamp": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/clamp/-/clamp-1.0.1.tgz",
+      "integrity": "sha1-ZqDmQBGBbjcZaCj9yMjBRzEshjQ="
+    },
     "cli-boxes": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,12 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "7zip": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/7zip/-/7zip-0.0.6.tgz",
+      "integrity": "sha1-nK+xca+CMpSQNTtIFvAzR6oVCjA=",
+      "dev": true
+    },
     "7zip-bin": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/7zip-bin/-/7zip-bin-4.0.2.tgz",
@@ -641,6 +647,12 @@
         "which": "1.3.1"
       }
     },
+    "cross-unzip": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/cross-unzip/-/cross-unzip-0.0.2.tgz",
+      "integrity": "sha1-UYO8R6CVWb78+YzEZXlkmZNZNy8=",
+      "dev": true
+    },
     "crypto-random-string": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
@@ -787,6 +799,18 @@
         "sanitize-filename": "1.6.1",
         "update-notifier": "2.5.0",
         "yargs": "12.0.2"
+      }
+    },
+    "electron-devtools-installer": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/electron-devtools-installer/-/electron-devtools-installer-2.2.4.tgz",
+      "integrity": "sha512-b5kcM3hmUqn64+RUcHjjr8ZMpHS2WJ5YO0pnG9+P/RTdx46of/JrEjuciHWux6pE+On6ynWhHJF53j/EDJN0PA==",
+      "dev": true,
+      "requires": {
+        "7zip": "0.0.6",
+        "cross-unzip": "0.0.2",
+        "rimraf": "2.6.2",
+        "semver": "5.5.1"
       }
     },
     "electron-download": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
   },
   "devDependencies": {
     "electron": "^2.0.8",
-    "electron-builder": "^20.28.4"
+    "electron-builder": "^20.28.4",
+    "electron-devtools-installer": "^2.2.4"
   },
   "build": {
     "appId": "com.randompoison.editor"

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "license": "MIT",
   "dependencies": {
     "bulma": "^0.7.1",
+    "clamp": "^1.0.1",
     "node-ipc": "^9.1.1",
     "npm": "^6.4.1",
     "vue": "^2.5.17",

--- a/renderer.js
+++ b/renderer.js
@@ -13,6 +13,7 @@ let app = new Vue({
         process: process,
 
         // A map containing the data for each game currently connected to the editor.
+        gameIds: [],
         games: {},
         activeGame: 0,
 
@@ -30,11 +31,13 @@ let app = new Vue({
         },
 
         selectEntity: function(entity) {
-            this.games[this.activeGame].selectedEntity = entity;
+            let gameId = this.gameIds[this.activeGame];
+            this.games[gameId].selectedEntity = entity;
         },
 
         selectTab: function(index) {
-            this.games[this.activeGame].activeTab = index;
+            let gameId = this.gameIds[this.activeGame];
+            this.games[gameId].activeTab = index;
         },
     }
 });
@@ -42,6 +45,8 @@ exports.app = app;
 
 ipcRenderer.on('connect', (event, data) => {
     console.log('Connected to new game:', data);
+
+    app.gameIds.push(data.id);
 
     let game = {
         entities: [],
@@ -69,10 +74,7 @@ ipcRenderer.on('connect', (event, data) => {
     };
     game.update(data.data);
 
-    let tmp = {};
-    tmp[data.id] = game;
-
-    app.games = Object.assign({}, app.games, tmp);
+    Vue.set(app.games, data.id, game);
 });
 
 ipcRenderer.on('disconnect', (event, data) => {

--- a/renderer.js
+++ b/renderer.js
@@ -16,7 +16,7 @@ let app = new Vue({
         // A map containing the data for each game currently connected to the editor.
         gameIds: [],
         games: {},
-        activeGame: 0,
+        activeGameIndex: 0,
 
         // The list of tabs that are available for each game. Each game tracks its own state for
         // which tab is currently selected.
@@ -28,17 +28,25 @@ let app = new Vue({
 
     methods: {
         selectGame: function(index) {
-            this.activeGame = index;
+            this.activeGameIndex = index;
         },
 
         selectEntity: function(entity) {
-            let gameId = this.gameIds[this.activeGame];
+            let gameId = this.gameIds[this.activeGameIndex];
             this.games[gameId].selectedEntity = entity;
         },
 
         selectTab: function(index) {
-            let gameId = this.gameIds[this.activeGame];
+            let gameId = this.gameIds[this.activeGameIndex];
             this.games[gameId].activeTab = index;
+        },
+
+        activeGameId: function() {
+            return this.gameIds[this.activeGameIndex];
+        },
+
+        activeGame: function() {
+            return this.games[this.activeGameId()];
         },
     }
 });
@@ -55,12 +63,12 @@ ipcRenderer.on('disconnect', (event, data) => {
 
         // Update the index of the currently active game tab if selected tab was after the
         // removed tab.
-        if (index < app.activeGame) {
-            app.activeGame -= 1;
+        if (index < app.activeGameIndex) {
+            app.activeGameIndex -= 1;
         }
-        app.activeGame = clamp(app.activeGame, 0, app.gameIds.length - 1);
+        app.activeGameIndex = clamp(app.activeGameIndex, 0, app.gameIds.length - 1);
 
-        console.log(`Disconnected from ${data.id}, active game is now ${app.activeGame}, current game IDs`, app.gameIds);
+        console.log(`Disconnected from ${data.id}, active game is now ${app.activeGameIndex}, current game IDs`, app.gameIds);
     } else {
         console.log(`Disconnected from ${data.id} but game was not in list of game IDs`, app.gameIds);
     }

--- a/renderer.js
+++ b/renderer.js
@@ -43,7 +43,7 @@ exports.app = app;
 ipcRenderer.on('connect', (event, data) => {
     console.log('Connected to new game:', data);
 
-    app.games[data.id] = {
+    let game = {
         entities: [],
         components: [],
         resources: [],
@@ -67,9 +67,17 @@ ipcRenderer.on('connect', (event, data) => {
             this.resources = sortedResources;
         },
     };
+    game.update(data.data);
+
+    let tmp = {};
+    tmp[data.id] = game;
+
+    app.games = Object.assign({}, app.games, tmp);
 });
 
 ipcRenderer.on('disconnect', (event, data) => {
+    console.log('Disconnected from a game:', data);
+
     delete app.games[data.id];
 
     // TODO: We might need to update the index of the active game, depending on where in the list
@@ -77,10 +85,11 @@ ipcRenderer.on('disconnect', (event, data) => {
 });
 
 ipcRenderer.on('update', (event, data) => {
-    console.log(data);
-
-    let game = app.games[data.id];
-    game.update(data.data);
+    console.log('Updating data:', data);
+    if (data.id in app.games) {
+        let game = app.games[data.id];
+        game.update(data.data);
+    }
 });
 
 /**

--- a/renderer.js
+++ b/renderer.js
@@ -44,40 +44,6 @@ let app = new Vue({
 });
 exports.app = app;
 
-ipcRenderer.on('connect', (event, data) => {
-    console.log('Connected to new game:', data);
-
-    app.gameIds.push(data.id);
-
-    let game = {
-        entities: [],
-        components: [],
-        resources: [],
-        rawComponents: null,
-        selectedEntity: null,
-        activeTab: 0,
-
-        update: function(data) {
-            this.entities = data.entities;
-
-            // Sort components before updating the local data to ensure that components always appear
-            // in the same order regardless of the order they are sent in.
-            var sortedComponents = data.components;
-            sortedComponents.sort(compareNamed);
-            this.components = sortedComponents;
-
-            // Sort resources before updating the local data to ensure that resources always appear
-            // in the same order regardless of the order they are sent in.
-            var sortedResources = data.resources;
-            sortedResources.sort(compareNamed);
-            this.resources = sortedResources;
-        },
-    };
-    game.update(data.data);
-
-    Vue.set(app.games, data.id, game);
-});
-
 ipcRenderer.on('disconnect', (event, data) => {
     var index = app.gameIds.indexOf(data.id);
     if (index !== -1) {
@@ -100,10 +66,42 @@ ipcRenderer.on('disconnect', (event, data) => {
     }
 });
 
-ipcRenderer.on('update', (event, data) => {
+ipcRenderer.on('data', (event, data) => {
     if (data.id in app.games) {
         let game = app.games[data.id];
         game.update(data.data);
+    } else {
+        console.log('Connected to new game:', data);
+
+        app.gameIds.push(data.id);
+
+        let game = {
+            entities: [],
+            components: [],
+            resources: [],
+            rawComponents: null,
+            selectedEntity: null,
+            activeTab: 0,
+
+            update: function(data) {
+                this.entities = data.entities;
+
+                // Sort components before updating the local data to ensure that components always appear
+                // in the same order regardless of the order they are sent in.
+                var sortedComponents = data.components;
+                sortedComponents.sort(compareNamed);
+                this.components = sortedComponents;
+
+                // Sort resources before updating the local data to ensure that resources always appear
+                // in the same order regardless of the order they are sent in.
+                var sortedResources = data.resources;
+                sortedResources.sort(compareNamed);
+                this.resources = sortedResources;
+            },
+        };
+        game.update(data.data);
+
+        Vue.set(app.games, data.id, game);
     }
 });
 

--- a/renderer.js
+++ b/renderer.js
@@ -6,19 +6,22 @@ let app = new Vue({
     components: {
         VueJsonPretty,
     },
+
     data: {
+        // Capture data about the Electron process so that we can display it in the app if we want.
         process: process,
-        entities: [],
-        components: [],
-        resources: [],
-        rawComponents: null,
-        selectedEntity: null,
+
+        // A map containing the data for each game currently connected to the editor.
+        games: {},
+
+        // The list of tabs that are available for each game. Each game tracks its own state for
+        // which tab is currently selected.
         tabs: [
             'Entities',
             'Resources',
         ],
-        activeTab: 0,
     },
+
     methods: {
         selectEntity: function(entity) {
             this.selectedEntity = entity;
@@ -31,22 +34,49 @@ let app = new Vue({
 });
 exports.app = app;
 
-ipcRenderer.on('message', (event, data) => {
-    app.entities = data.entities;
+ipcRenderer.on('connect', (event, data) => {
+    app.games[data.id] = {
+        entities: [],
+        components: [],
+        resources: [],
+        rawComponents: null,
+        selectedEntity: null,
+        activeTab: 0,
 
-    // Sort components before updating the local data to ensure that components always appear
-    // in the same order regardless of the order they are sent in.
-    var sortedComponents = data.components;
-    sortedComponents.sort(compareNamed);
-    app.components = sortedComponents;
+        update: function(data) {
+            this.entities = data.entities;
 
-    // Sort resources before updating the local data to ensure that resources always appear
-    // in the same order regardless of the order they are sent in.
-    var sortedResources = data.resources;
-    sortedResources.sort(compareNamed);
-    app.resources = sortedResources;
+            // Sort components before updating the local data to ensure that components always appear
+            // in the same order regardless of the order they are sent in.
+            var sortedComponents = data.components;
+            sortedComponents.sort(compareNamed);
+            this.components = sortedComponents;
+
+            // Sort resources before updating the local data to ensure that resources always appear
+            // in the same order regardless of the order they are sent in.
+            var sortedResources = data.resources;
+            sortedResources.sort(compareNamed);
+            this.resources = sortedResources;
+        },
+    };
 });
 
+ipcRenderer.on('disconnect', (event, data) => {
+    delete app.games[data.id];
+});
+
+ipcRenderer.on('update', (event, data) => {
+    console.log(data);
+
+    let game = app.games[data.id];
+    game.update(data.data);
+});
+
+/**
+ * Compares two objects by name, returning a numeric value based on their relative ordering.
+ *
+ * Useful for sorting a list of objects by their name, rather than their natural ordering.
+ */
 function compareNamed(left, right) {
     if (left.name < right.name) { return -1; }
     if (left.name > right.name) { return 1; }


### PR DESCRIPTION
Closes #5, Fixes #10

Switch back to a more standard single-window setup, where new tabs are automatically added and removed as games connect to the editor. If no game is connected, then the editor displays a message letting the player know they need to run a game to use the editor.