### PR TITLE
Add simple log tab

### DIFF
--- a/index.html
+++ b/index.html
@@ -119,6 +119,13 @@
             <vue-json-pretty :data="resource.data"></vue-json-pretty>
           </div>
         </div>
+
+        <!-- Log tab. -->
+        <div v-if="activeGame().activeTab === 2">
+          <div v-for="log in activeGame().logs">
+            [{{ log.level }}] [{{ log.target }}] {{ log.message }}
+          </div>
+        </div>
       </section>
     </div>
 

--- a/renderer.js
+++ b/renderer.js
@@ -3,6 +3,8 @@ const VueJsonPretty = require('vue-json-pretty').default;
 const { default: installExtension, VUEJS_DEVTOOLS } = require('electron-devtools-installer');
 const clamp = require('clamp');
 
+const MAX_LOGS = 500;
+
 let app = new Vue({
     el: '#app',
     components: {
@@ -23,6 +25,7 @@ let app = new Vue({
         tabs: [
             'Entities',
             'Resources',
+            'Log',
         ],
     },
 
@@ -87,10 +90,10 @@ ipcRenderer.on('data', (event, data) => {
             entities: [],
             components: [],
             resources: [],
+            logs: [],
             rawComponents: null,
             selectedEntity: null,
             activeTab: 0,
-
             update: function(data) {
                 this.entities = data.entities;
 
@@ -105,7 +108,19 @@ ipcRenderer.on('data', (event, data) => {
                 var sortedResources = data.resources;
                 sortedResources.sort(compareNamed);
                 this.resources = sortedResources;
+
+                for (message of data.messages) {
+                    if (message.type === 'log') {
+                        this.insertLog(message.data);
+                    }
+                }
             },
+            insertLog: function(log) {
+                if (this.logs.length >= MAX_LOGS) {
+                    this.logs.shift();
+                }
+                this.logs.push(log);
+            }
         };
         game.update(data.data);
 


### PR DESCRIPTION
Lists incoming log messages from the game in a very plain way.
Currently arbitrarily set to only show the 500 latest logs. However since there are fairly uninteresting log messages being sent every frame interesting logs quickly disappear. Perhaps a fixed number of logs should be stored per (log-level, target) combination.

Since messages are only sent once, there was an issue where the first messages were not shown due to the window having to load first. This seems to have been fixed by moving to a single window layout.

Resolves #6 