### PR TITLE
Add support for receiving partial data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,13 @@ where applicable.
 
 ## [Unreleased]
 
-### Breaking Changes
+### Added
 
 * Switch to raw buffers in order to support reassembling split messages. ([#31])
+* Support for receiving partial data from the game. ([#33])
 
 [#31]: https://github.com/randomPoison/amethyst-editor/pull/31
+[#33]: https://github.com/randomPoison/amethyst-editor/pull/33
 
 ## [0.1.0] - 2018-10-03
 

--- a/renderer.js
+++ b/renderer.js
@@ -94,23 +94,31 @@ ipcRenderer.on('data', (event, data) => {
             selectedEntity: null,
             activeTab: 0,
             update: function(data) {
-                this.entities = data.entities;
+                if (data.entities != null) {
+                    this.entities = data.entities;
+                }
 
-                // Sort components before updating the local data to ensure that components always appear
-                // in the same order regardless of the order they are sent in.
-                var sortedComponents = data.components;
-                sortedComponents.sort(compareNamed);
-                this.components = sortedComponents;
+                if (data.components != null) {
+                    // Sort components before updating the local data to ensure that components always appear
+                    // in the same order regardless of the order they are sent in.
+                    var sortedComponents = data.components;
+                    sortedComponents.sort(compareNamed);
+                    this.components = sortedComponents;
+                }
 
-                // Sort resources before updating the local data to ensure that resources always appear
-                // in the same order regardless of the order they are sent in.
-                var sortedResources = data.resources;
-                sortedResources.sort(compareNamed);
-                this.resources = sortedResources;
+                if (data.resources != null) {
+                    // Sort resources before updating the local data to ensure that resources always appear
+                    // in the same order regardless of the order they are sent in.
+                    var sortedResources = data.resources;
+                    sortedResources.sort(compareNamed);
+                    this.resources = sortedResources;
+                }
 
-                for (message of data.messages) {
-                    if (message.type === 'log') {
-                        this.insertLog(message.data);
+                if (data.messages != null) {
+                    for (message of data.messages) {
+                        if (message.type === 'log') {
+                            this.insertLog(message.data);
+                        }
                     }
                 }
             },


### PR DESCRIPTION
This allows the game to only send partial data on some frames without causing the editor to display incorrect information. This is a performance optimization that will allow the game to send data less frequently, which should improve responsiveness in the editor.