### PR TITLE
Add support for editing resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ where applicable.
 
 ## [Unreleased]
 
+### Added
+
+* :tada: Support for editing resources! :tada: ([#34])
+
+[#34]: https://github.com/randomPoison/amethyst-editor/pull/34
+
 ## [0.2.0] - 2018-10-14
 
 ### Added

--- a/components/data-display.js
+++ b/components/data-display.js
@@ -35,7 +35,16 @@ Vue.component('data-display', {
     methods: {
         applyEdits: function() {
             this.$emit('submit', this.editedValue);
+            this.clearEdits();
+        },
+
+        clearEdits: function() {
             this.edits = {};
+            if (this.$refs.nestedData != null) {
+                for (let child of this.$refs.nestedData) {
+                    child.clearEdits();
+                }
+            }
         }
     },
 
@@ -51,6 +60,7 @@ Vue.component('data-display', {
                             v-model="edits[key]"
                             v-on:input="$emit('input', editedValue)"
                             v-on:submit.prevent="applyEdits()"
+                            ref="nestedData"
                             :isRoot="false"
                         ></data-display>
                     </template>

--- a/components/data-display.js
+++ b/components/data-display.js
@@ -1,11 +1,53 @@
 Vue.component('data-display', {
     props: {
         data: [Object, Array],
-        isRoot: {
-            type: Boolean,
-            default: true,
-        },
     },
+
+    computed: {
+        hasEdits: function() {
+            if (this.$refs.nestedData != null) {
+                return this.$refs.nestedData.hasEdits;
+            }
+
+            return false;
+        },
+
+        editedValue: function() {
+            return this.$refs.nestedData.editedValue;
+        }
+    },
+
+    methods: {
+        submitEdits: function() {
+            this.$emit('submit', this.editedValue);
+            this.clearEdits();
+        },
+
+        clearEdits: function() {
+            this.edits = {};
+            if (this.$refs.nestedData != null) {
+                this.$refs.nestedData.clearEdits();
+            }
+        }
+    },
+
+    template: `
+        <form v-on:submit.prevent="submitEdits()" class="data-display">
+            <nested-data
+                :data="data"
+                ref="nestedData"
+            ></nested-data>
+
+            <input
+                type="submit"
+                class="button is-fullwidth is-primary"
+            >
+        </form>
+    `,
+});
+
+Vue.component('nested-data', {
+    props: ['data'],
 
     data: function() {
         return {
@@ -33,11 +75,6 @@ Vue.component('data-display', {
     },
 
     methods: {
-        applyEdits: function() {
-            this.$emit('submit', this.editedValue);
-            this.clearEdits();
-        },
-
         clearEdits: function() {
             this.edits = {};
             if (this.$refs.nestedData != null) {
@@ -49,55 +86,41 @@ Vue.component('data-display', {
     },
 
     template: `
-        <form v-on:submit.prevent="" class="data-display" v-bind:class="{ 'is-root': isRoot }">
-            <ul>
-                <li v-for="(value, key) in data">
-
-                    <template v-if="value instanceof Object || value instanceof Array">
-                        <label class="label">{{ key }}</label>
-                        <data-display
-                            :data="value"
-                            v-model="edits[key]"
-                            v-on:input="$emit('input', editedValue)"
-                            v-on:submit.prevent="applyEdits()"
-                            ref="nestedData"
-                            :isRoot="false"
-                        ></data-display>
-                    </template>
-                    <template v-else>
-                        <div class="field is-horizontal">
-                            <div class="field-label">
-                                <label class="label">{{ key }}</label>
-                            </div>
-                            <input
-                                v-if="typeof value === 'number'"
-                                v-model.number="edits[key]"
-                                v-bind:placeholder="value"
-                                v-on:input="$emit('input', editedValue)"
-                                v-on:submit.prevent="applyEdits()"
-                                type="number"
-                                class="input"
-                            >
-                            <input
-                                v-else
-                                v-model="edits[key]"
-                                v-bind:placeholder="value"
-                                v-on:input="$emit('input', editedValue)"
-                                v-on:submit.prevent="applyEdits()"
-                                class="input"
-                            >
+        <ul>
+            <li v-for="(value, key) in data">
+                <template v-if="value instanceof Object || value instanceof Array">
+                    <label class="label">{{ key }}</label>
+                    <nested-data
+                        :data="value"
+                        v-model="edits[key]"
+                        v-on:input="$emit('input', editedValue)"
+                        ref="nestedData"
+                        :isRoot="false"
+                    ></nested-data>
+                </template>
+                <template v-else>
+                    <div class="field is-horizontal">
+                        <div class="field-label">
+                            <label class="label">{{ key }}</label>
                         </div>
-                    </template>
-                </li>
-            </ul>
-
-            <button
-                v-if="isRoot && hasEdits"
-                v-on:click="applyEdits()"
-                class="button is-fullwidth is-primary"
-            >
-                Apply
-            </button>
-        </form>
+                        <input
+                            v-if="typeof value === 'number'"
+                            v-model.number="edits[key]"
+                            v-bind:placeholder="value"
+                            v-on:input="$emit('input', editedValue)"
+                            type="number"
+                            class="input"
+                        >
+                        <input
+                            v-else
+                            v-model="edits[key]"
+                            v-bind:placeholder="value"
+                            v-on:input="$emit('input', editedValue)"
+                            class="input"
+                        >
+                    </div>
+                </template>
+            </li>
+        </ul>
     `,
 });

--- a/components/data-display.js
+++ b/components/data-display.js
@@ -9,34 +9,33 @@ Vue.component('data-display', {
 
     data: function() {
         return {
-            editedValues: {},
+            edits: {},
         };
     },
 
     computed: {
         hasEdits: function() {
-            for (let prop in this.editedValues) {
-                if (this.editedValues.hasOwnProperty(prop)) {
+            for (let prop in this.edits) {
+                if (this.edits.hasOwnProperty(prop)) {
                     return true;
                 }
             }
 
             return false;
         },
+
+        editedValue: function() {
+            // Create a copy of the data, overriding any edited fields with the
+            // corresponding values.
+            let copy = Object.assign({}, this.data);
+            return Object.assign(copy, this.edits);
+        }
     },
 
     methods: {
         applyEdits: function() {
-            // Create a copy of the data, overriding any edited fields with the
-            // corresponding values.
-            let copy = Object.assign({}, this.data);
-            let edited = Object.assign(copy, this.editedValues);
-
-            // Discard the previous edits.
-            this.editedValues = {};
-
-            // Emit the edited data.
-            this.$emit('save-edits', edited);
+            this.$emit('submit', this.editedValue);
+            this.edits = {};
         }
     },
 
@@ -47,7 +46,13 @@ Vue.component('data-display', {
 
                     <template v-if="value instanceof Object || value instanceof Array">
                         <label class="label">{{ key }}</label>
-                        <data-display :data="value" :isRoot="false"></data-display>
+                        <data-display
+                            :data="value"
+                            v-model="edits[key]"
+                            v-on:input="$emit('input', editedValue)"
+                            v-on:submit.prevent="applyEdits()"
+                            :isRoot="false"
+                        ></data-display>
                     </template>
                     <template v-else>
                         <div class="field is-horizontal">
@@ -56,15 +61,18 @@ Vue.component('data-display', {
                             </div>
                             <input
                                 v-if="typeof value === 'number'"
-                                v-model.number="editedValues[key]"
+                                v-model.number="edits[key]"
                                 v-bind:placeholder="value"
+                                v-on:input="$emit('input', editedValue)"
+                                v-on:submit.prevent="applyEdits()"
                                 type="number"
                                 class="input"
                             >
                             <input
                                 v-else
-                                v-model="editedValues[key]"
+                                v-model="edits[key]"
                                 v-bind:placeholder="value"
+                                v-on:input="$emit('input', editedValue)"
                                 v-on:submit.prevent="applyEdits()"
                                 class="input"
                             >

--- a/components/data-display.js
+++ b/components/data-display.js
@@ -26,16 +26,22 @@ Vue.component('data-display', {
     },
 
     methods: {
-        generateEdited: function() {
+        applyEdits: function() {
+            // Create a copy of the data, overriding any edited fields with the
+            // corresponding values.
             let copy = Object.assign({}, this.data);
             let edited = Object.assign(copy, this.editedValues);
+
+            // Discard the previous edits.
             this.editedValues = {};
-            return edited;
-        },
+
+            // Emit the edited data.
+            this.$emit('save-edits', edited);
+        }
     },
 
     template: `
-        <div class="data-display" v-bind:class="{ 'is-root': isRoot }">
+        <form v-on:submit.prevent="" class="data-display" v-bind:class="{ 'is-root': isRoot }">
             <ul>
                 <li v-for="(value, key) in data">
 
@@ -59,6 +65,7 @@ Vue.component('data-display', {
                                 v-else
                                 v-model="editedValues[key]"
                                 v-bind:placeholder="value"
+                                v-on:submit.prevent="applyEdits()"
                                 class="input"
                             >
                         </div>
@@ -67,13 +74,12 @@ Vue.component('data-display', {
             </ul>
 
             <button
-                v-if="isRoot"
-                v-on:click="$emit('save-edits', generateEdited())"
+                v-if="isRoot && hasEdits"
+                v-on:click="applyEdits()"
                 class="button is-fullwidth is-primary"
-                v-bind:disabled="!hasEdits"
             >
                 Apply
             </button>
-        </div>
+        </form>
     `,
 });

--- a/components/data-display.js
+++ b/components/data-display.js
@@ -13,6 +13,18 @@ Vue.component('data-display', {
         };
     },
 
+    computed: {
+        hasEdits: function() {
+            for (let prop in this.editedValues) {
+                if (this.editedValues.hasOwnProperty(prop)) {
+                    return true;
+                }
+            }
+
+            return false;
+        },
+    },
+
     methods: {
         generateEdited: function() {
             let copy = Object.assign({}, this.data);
@@ -54,7 +66,14 @@ Vue.component('data-display', {
                 </li>
             </ul>
 
-            <button v-if="isRoot" v-on:click="$emit('save-edits', generateEdited())">Save</button>
+            <button
+                v-if="isRoot"
+                v-on:click="$emit('save-edits', generateEdited())"
+                class="button is-fullwidth is-primary"
+                v-bind:disabled="!hasEdits"
+            >
+                Apply
+            </button>
         </div>
     `,
 });

--- a/components/data-display.js
+++ b/components/data-display.js
@@ -1,0 +1,19 @@
+Vue.component('data-display', {
+    props: ['data'],
+    template: `
+        <div>
+            <ul>
+                <li v-for="(value, key) in data">
+                    {{ key }}:
+
+                    <template v-if="typeof value === 'object'">
+                        <data-display :data="value"></data-display>
+                    </template>
+                    <template v-else>
+                        {{ value }}
+                    </template>
+                </li>
+            </ul>
+        </div>
+    `,
+});

--- a/components/data-display.js
+++ b/components/data-display.js
@@ -16,7 +16,9 @@ Vue.component('data-display', {
     methods: {
         generateEdited: function() {
             let copy = Object.assign({}, this.data);
-            return Object.assign(copy, this.editedValues);
+            let edited = Object.assign(copy, this.editedValues);
+            this.editedValues = {};
+            return edited;
         },
     },
 

--- a/components/data-display.js
+++ b/components/data-display.js
@@ -3,18 +3,14 @@ Vue.component('data-display', {
         data: [Object, Array],
     },
 
+    data: function() {
+        return {
+            editedValue: null,
+        };
+    },
+
     computed: {
-        hasEdits: function() {
-            if (this.$refs.nestedData != null) {
-                return this.$refs.nestedData.hasEdits;
-            }
-
-            return false;
-        },
-
-        editedValue: function() {
-            return this.$refs.nestedData.editedValue;
-        }
+        hasEdits: function() { return this.editedValue != null; }
     },
 
     methods: {
@@ -24,7 +20,7 @@ Vue.component('data-display', {
         },
 
         clearEdits: function() {
-            this.edits = {};
+            this.editedValue = null;
             if (this.$refs.nestedData != null) {
                 this.$refs.nestedData.clearEdits();
             }
@@ -35,10 +31,12 @@ Vue.component('data-display', {
         <form v-on:submit.prevent="submitEdits()" class="data-display">
             <nested-data
                 :data="data"
+                v-model="editedValue"
                 ref="nestedData"
             ></nested-data>
 
             <input
+                v-if="hasEdits"
                 type="submit"
                 class="button is-fullwidth is-primary"
             >

--- a/components/data-display.js
+++ b/components/data-display.js
@@ -7,17 +7,32 @@ Vue.component('data-display', {
         },
     },
 
+    data: function() {
+        return {
+            editedValues: {},
+        };
+    },
+
     template: `
-        <div>
+        <div class="data-display" v-bind:class="{ 'is-root': isRoot }">
             <ul>
                 <li v-for="(value, key) in data">
-                    {{ key }}:
 
                     <template v-if="value instanceof Object || value instanceof Array">
+                        <label class="label">{{ key }}</label>
                         <data-display :data="value" :isRoot="false"></data-display>
                     </template>
                     <template v-else>
-                        {{ value }}
+                        <div class="field is-horizontal">
+                            <div class="field-label">
+                                <label class="label">{{ key }}</label>
+                            </div>
+                            <input
+                                v-model="editedValues[key]"
+                                v-bind:placeholder="value"
+                                class="input"
+                            >
+                        </div>
                     </template>
                 </li>
             </ul>

--- a/components/data-display.js
+++ b/components/data-display.js
@@ -13,6 +13,13 @@ Vue.component('data-display', {
         };
     },
 
+    methods: {
+        generateEdited: function() {
+            let copy = Object.assign({}, this.data);
+            return Object.assign(copy, this.editedValues);
+        },
+    },
+
     template: `
         <div class="data-display" v-bind:class="{ 'is-root': isRoot }">
             <ul>
@@ -37,7 +44,7 @@ Vue.component('data-display', {
                 </li>
             </ul>
 
-            <button v-if="isRoot" v-on:click="$emit('save-edits', data)">Save</button>
+            <button v-if="isRoot" v-on:click="$emit('save-edits', generateEdited())">Save</button>
         </div>
     `,
 });

--- a/components/data-display.js
+++ b/components/data-display.js
@@ -1,3 +1,13 @@
+/**
+ * Component for displaying and editing arbitrary JSON data.
+ *
+ * Displays arbitrary, potentially nested JSON data (given as an Object or
+ * Array) in a clean, user-friendly way. Supports editing one or more fields
+ * of the input data and "submitting" the modified data like a form.
+ *
+ * Internally uses `<nested-data>` to recursively display nested object data,
+ * including tracking the modified version of the data as the user makes edits.
+ */
 Vue.component('data-display', {
     props: {
         data: [Object, Array],
@@ -44,8 +54,17 @@ Vue.component('data-display', {
     `,
 });
 
+/**
+ * Helper component for recursively displaying nested data in `<data-display>`.
+ *
+ * Recursively renders data from an arbitray `Object` or `Array`, showing each
+ * field of the the object as an editable form input. Supports tracking which
+ * fields have been edited, and emits the modified data as an "input" event.
+ */
 Vue.component('nested-data', {
-    props: ['data'],
+    props: {
+        data: [Object, Array],
+    },
 
     data: function() {
         return {
@@ -69,7 +88,7 @@ Vue.component('nested-data', {
             // corresponding values.
             let copy = Object.assign({}, this.data);
             return Object.assign(copy, this.edits);
-        }
+        },
     },
 
     methods: {
@@ -80,7 +99,7 @@ Vue.component('nested-data', {
                     child.clearEdits();
                 }
             }
-        }
+        },
     },
 
     template: `

--- a/components/data-display.js
+++ b/components/data-display.js
@@ -37,6 +37,14 @@ Vue.component('data-display', {
                                 <label class="label">{{ key }}</label>
                             </div>
                             <input
+                                v-if="typeof value === 'number'"
+                                v-model.number="editedValues[key]"
+                                v-bind:placeholder="value"
+                                type="number"
+                                class="input"
+                            >
+                            <input
+                                v-else
                                 v-model="editedValues[key]"
                                 v-bind:placeholder="value"
                                 class="input"

--- a/components/data-display.js
+++ b/components/data-display.js
@@ -1,19 +1,28 @@
 Vue.component('data-display', {
-    props: ['data'],
+    props: {
+        data: [Object, Array],
+        isRoot: {
+            type: Boolean,
+            default: true,
+        },
+    },
+
     template: `
         <div>
             <ul>
                 <li v-for="(value, key) in data">
                     {{ key }}:
 
-                    <template v-if="typeof value === 'object'">
-                        <data-display :data="value"></data-display>
+                    <template v-if="value instanceof Object || value instanceof Array">
+                        <data-display :data="value" :isRoot="false"></data-display>
                     </template>
                     <template v-else>
                         {{ value }}
                     </template>
                 </li>
             </ul>
+
+            <button v-if="isRoot" v-on:click="$emit('save-edits', data)">Save</button>
         </div>
     `,
 });

--- a/index.html
+++ b/index.html
@@ -102,9 +102,9 @@
               class="box content"
             >
               <h3 class="title is-3">{{ componentType.name }}</h3>
-                <vue-json-pretty
+                <data-display
                   :data="componentType.data[activeGame().selectedEntity]"
-                ></vue-json-pretty>
+                ></data-display>
             </div>
           </div>
 
@@ -115,7 +115,7 @@
         <div v-if="activeGame().activeTab === 1" class="main vertical-panel scrollable">
           <div v-for="resource in activeGame().resources" class="box content">
             <h3 class="title is-3">{{ resource.name }}</h3>
-            <vue-json-pretty :data="resource.data"></vue-json-pretty>
+            <data-display :data="resource.data"></data-display>
           </div>
         </div>
 

--- a/index.html
+++ b/index.html
@@ -99,7 +99,7 @@
             <div
               v-for="componentType in activeGame().components"
               v-if="componentType.data[activeGame().selectedEntity] != null"
-              class="box content"
+              class="box"
             >
               <h3 class="title is-3">{{ componentType.name }}</h3>
                 <data-display
@@ -113,7 +113,7 @@
 
         <!-- Resources tab. -->
         <div v-if="activeGame().activeTab === 1" class="main vertical-panel scrollable">
-          <div v-for="resource in activeGame().resources" class="box content">
+          <div v-for="resource in activeGame().resources" class="box">
             <h3 class="title is-3">{{ resource.name }}</h3>
             <data-display :data="resource.data" v-on:save-edits="activeGame().editResource(resource.name, $event)"></data-display>
           </div>

--- a/index.html
+++ b/index.html
@@ -115,7 +115,7 @@
         <div v-if="activeGame().activeTab === 1" class="main vertical-panel scrollable">
           <div v-for="resource in activeGame().resources" class="box content">
             <h3 class="title is-3">{{ resource.name }}</h3>
-            <data-display :data="resource.data"></data-display>
+            <data-display :data="resource.data" v-on:save-edits="activeGame().editResource(resource.name, $event)"></data-display>
           </div>
         </div>
 

--- a/index.html
+++ b/index.html
@@ -115,7 +115,10 @@
         <div v-if="activeGame().activeTab === 1" class="main vertical-panel scrollable">
           <div v-for="resource in activeGame().resources" class="box">
             <h3 class="title is-3">{{ resource.name }}</h3>
-            <data-display :data="resource.data" v-on:save-edits="activeGame().editResource(resource.name, $event)"></data-display>
+            <data-display
+              :data="resource.data"
+              v-on:submit="activeGame().editResource(resource.name, $event)"
+            ></data-display>
           </div>
         </div>
 

--- a/main.js
+++ b/main.js
@@ -123,14 +123,11 @@ function onGameMessage(data, socket) {
 }
 
 ipcMain.on('update-resource', (event, arg) => {
-    console.log('arg:', arg);
-
     let gameId = arg.gameId;
     if (!(gameId in sockets)) {
         return;
     }
     let socket = sockets[gameId];
-    console.log('Sending to socket:', socket);
 
     var message = {
         type: 'ResourceUpdate',

--- a/package.json
+++ b/package.json
@@ -15,8 +15,7 @@
     "clamp": "^1.0.1",
     "node-ipc": "^9.1.1",
     "npm": "^6.4.1",
-    "vue": "^2.5.17",
-    "vue-json-pretty": "^1.4.1"
+    "vue": "^2.5.17"
   },
   "devDependencies": {
     "electron": "^3.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amethyst-editor",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "An experimental editor for the Amethyst game engine",
   "main": "main.js",
   "scripts": {

--- a/renderer.js
+++ b/renderer.js
@@ -8,9 +8,6 @@ const MAX_LOGS = 500;
 
 let app = new Vue({
     el: '#app',
-    components: {
-        VueJsonPretty,
-    },
 
     data: {
         // Capture data about the Electron process so that we can display it in the app if we want.

--- a/renderer.js
+++ b/renderer.js
@@ -1,6 +1,8 @@
 const { ipcRenderer } = require('electron');
-const VueJsonPretty = require('vue-json-pretty').default;
 const clamp = require('clamp');
+
+// Load custom components.
+require('./components/data-display.js');
 
 const MAX_LOGS = 500;
 
@@ -113,18 +115,6 @@ ipcRenderer.on('data', (event, data) => {
                     var sortedResources = data.resources;
                     sortedResources.sort(compareNamed);
                     this.resources = sortedResources;
-
-                    for (var resource of sortedResources) {
-                        if (resource.name === 'ScoreBoard') {
-                            var updated = Object.assign({}, resource.data);
-                            updated.score_left = 77;
-                            ipcRenderer.send('update-resource', {
-                                gameId: this.gameId,
-                                id: resource.name,
-                                data: updated,
-                            });
-                        }
-                    }
                 }
 
                 if (data.messages != null) {

--- a/renderer.js
+++ b/renderer.js
@@ -93,6 +93,7 @@ ipcRenderer.on('data', (event, data) => {
             rawComponents: null,
             selectedEntity: null,
             activeTab: 0,
+
             update: function(data) {
                 if (data.entities != null) {
                     this.entities = data.entities;
@@ -122,12 +123,14 @@ ipcRenderer.on('data', (event, data) => {
                     }
                 }
             },
+
             insertLog: function(log) {
                 if (this.logs.length >= MAX_LOGS) {
                     this.logs.shift();
                 }
                 this.logs.push(log);
             },
+
             entityHasTags: function(entity) {
                 for (component of this.components) {
                     if (component.data[entity] === null) {
@@ -136,7 +139,17 @@ ipcRenderer.on('data', (event, data) => {
                 }
 
                 return false
-            }
+            },
+
+            editResource: function(id, data) {
+                console.log(`Edited resource ${id} in game ${this.gameId}:`, data);
+
+                ipcRenderer.send('update-resource', {
+                    gameId: this.gameId,
+                    id: id,
+                    data: data,
+                });
+            },
         };
         game.update(data.data);
 

--- a/renderer.js
+++ b/renderer.js
@@ -86,6 +86,7 @@ ipcRenderer.on('data', (event, data) => {
         app.gameIds.push(data.id);
 
         let game = {
+            gameId: data.id,
             entities: [],
             components: [],
             resources: [],
@@ -118,7 +119,8 @@ ipcRenderer.on('data', (event, data) => {
                             var updated = Object.assign({}, resource.data);
                             updated.score_left = 77;
                             ipcRenderer.send('update-resource', {
-                                type: resource.name,
+                                gameId: this.gameId,
+                                id: resource.name,
                                 data: updated,
                             });
                         }

--- a/renderer.js
+++ b/renderer.js
@@ -112,6 +112,17 @@ ipcRenderer.on('data', (event, data) => {
                     var sortedResources = data.resources;
                     sortedResources.sort(compareNamed);
                     this.resources = sortedResources;
+
+                    for (var resource of sortedResources) {
+                        if (resource.name === 'ScoreBoard') {
+                            var updated = Object.assign({}, resource.data);
+                            updated.score_left = 77;
+                            ipcRenderer.send('update-resource', {
+                                type: resource.name,
+                                data: updated,
+                            });
+                        }
+                    }
                 }
 
                 if (data.messages != null) {

--- a/style.css
+++ b/style.css
@@ -66,3 +66,15 @@ body {
   padding: 5px;
   border-bottom: 1px solid #dbdbdb;
 }
+
+.data-display {
+  list-style: none;
+}
+
+.data-display:not(.is-root) ul {
+  padding-left: 1.5em;
+}
+
+.data-display li {
+  margin: .4em 0;
+}

--- a/style.css
+++ b/style.css
@@ -71,7 +71,7 @@ body {
   list-style: none;
 }
 
-.data-display:not(.is-root) ul {
+.data-display ul:not(:first-child) {
   padding-left: 1.5em;
 }
 


### PR DESCRIPTION
Based on the functionality added in randomPoison/amethyst-editor-sync#25, this PR adds a new component for displaying and editing components/resources, and hooks up logic for submitting edited resource data to the game.

![edit-resources-mvp](https://user-images.githubusercontent.com/1900829/47197475-28b87880-d32c-11e8-9f81-66588a569068.gif)

* Remove vue-json-pretty and replace it with a custom `data-display` component.
* Implement support for nested data in `data-display` via a recursive `nested-data` component.
* Support editing fields within `data-display` and then submitting the edited data object like a standard form.
* Edit multiple fields and submit all changes at once.
* Editing works properly even with deeply nested data types.

